### PR TITLE
(kind of) works for goalf -> GCC

### DIFF
--- a/easybuild/toolchains/gcc.py
+++ b/easybuild/toolchains/gcc.py
@@ -29,8 +29,10 @@ EasyBuild support for GCC compiler toolchain.
 """
 
 from easybuild.toolchains.compiler.gcc import Gcc
+from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 
 
 class GccToolchain(Gcc):
     """Simple toolchain with just the GCC compilers."""
     NAME = 'GCC'
+    SUBTOOLCHAIN = DUMMY_TOOLCHAIN_NAME

--- a/easybuild/toolchains/goalf.py
+++ b/easybuild/toolchains/goalf.py
@@ -31,6 +31,7 @@ EasyBuild support for goalf compiler toolchain (includes GCC, OpenMPI, ATLAS, BL
 
 from easybuild.toolchains.compiler.gcc import Gcc
 from easybuild.toolchains.fft.fftw import Fftw
+from easybuild.toolchains.gompi import Gompi
 from easybuild.toolchains.linalg.atlas import Atlas
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 from easybuild.toolchains.mpi.openmpi import OpenMPI
@@ -39,3 +40,4 @@ from easybuild.toolchains.mpi.openmpi import OpenMPI
 class Goalf(Gcc, OpenMPI, Atlas, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, OpenMPI, ATLAS, ScaLAPACK and FFTW."""
     NAME = 'goalf'
+    SUBTOOLCHAIN = Gompi.NAME

--- a/easybuild/toolchains/gompi.py
+++ b/easybuild/toolchains/gompi.py
@@ -29,9 +29,11 @@ EasyBuild support for gompi compiler toolchain (includes GCC and OpenMPI).
 """
 
 from easybuild.toolchains.compiler.gcc import Gcc
+from easybuild.toolchains.gcc import GccToolchain
 from easybuild.toolchains.mpi.openmpi import OpenMPI
 
 
 class Gompi(Gcc, OpenMPI):
     """Compiler toolchain with GCC and OpenMPI."""
     NAME = 'gompi'
+    SUBTOOLCHAIN = GccToolchain.NAME

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -179,7 +179,7 @@ def replace_toolchain_with_hierarchy(item_specs, parent, retain_all_deps, use_an
                     break
         # Look for any matching easyconfig starting from the bottom
         if not resolved:
-            for tc in toolchains:
+            for tc in reversed(toolchains):
                 cand_dep['ec']['toolchain'] = tc
                 eb_file = robot_find_easyconfig(cand_dep['ec']['name'], det_full_ec_version(cand_dep['ec']))
                 if eb_file is not None:

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -179,7 +179,7 @@ def replace_toolchain_with_hierarchy(item_specs, parent, retain_all_deps, use_an
                     break
         # Look for any matching easyconfig starting from the bottom
         if not resolved:
-            for tc in reversed(toolchains):
+            for tc in toolchains:
                 cand_dep['ec']['toolchain'] = tc
                 eb_file = robot_find_easyconfig(cand_dep['ec']['name'], det_full_ec_version(cand_dep['ec']))
                 if eb_file is not None:


### PR DESCRIPTION
without:

```
$ eb OpenBabel-2.3.2-goalf-1.5.12-no-OFED-Python-2.7.5.eb -D | egrep '/GCC|CMake'
 * [ ] $CFGS/g/GCC/GCC-4.8.1.eb (module: GCC/4.8.1)
 * [ ] $CFGS/c/CMake/CMake-2.8.12-goalf-1.5.12-no-OFED.eb (module: CMake/2.8.12-goalf-1.5.12-no-OFED)
```

with (note: CMake is there _twice_):

```
$ eb OpenBabel-2.3.2-goalf-1.5.12-no-OFED-Python-2.7.5.eb -D | egrep '/GCC|CMake'
 * [ ] $CFGS/g/GCC/GCC-4.8.1.eb (module: GCC/4.8.1)
 * [ ] $CFGS/c/CMake/CMake-2.8.12-GCC-4.8.1.eb (module: CMake/2.8.12-GCC-4.8.1)
 * [ ] $CFGS/c/CMake/CMake-2.8.12-goalf-1.5.12-no-OFED.eb (module: CMake/2.8.12-goalf-1.5.12-no-OFED)
```
