### PR TITLE
fix default value for 'default_opt_level' build option

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -90,7 +90,6 @@ def mk_full_default_path(name, prefix=DEFAULT_PREFIX):
 BUILD_OPTIONS_CMDLINE = {
     None: [
         'aggregate_regtest',
-        'default_opt_level',
         'download_timeout',
         'dump_test_report',
         'easyblock',
@@ -170,6 +169,9 @@ BUILD_OPTIONS_CMDLINE = {
     GENERAL_CLASS: [
         'suffix_modules_path',
     ],
+    'defaultopt': [
+        'default_opt_level',
+    ]
 }
 # build option that do not have a perfectly matching command line option
 BUILD_OPTIONS_OTHER = {

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -73,7 +73,7 @@ from easybuild.tools.modules import Lmod
 from easybuild.tools.ordereddict import OrderedDict
 from easybuild.tools.run import run_cmd
 from easybuild.tools.package.utilities import avail_package_naming_schemes
-from easybuild.tools.toolchain.compiler import Compiler
+from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, Compiler
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.repository.repository import avail_repositories
 from easybuild.tools.version import this_is_easybuild
@@ -214,7 +214,7 @@ class EasyBuildOptions(GeneralOption):
             'cleanup-builddir': ("Cleanup build dir after successful installation.", None, 'store_true', True),
             'cleanup-tmpdir': ("Cleanup tmp dir after successful run.", None, 'store_true', True),
             'color': ("Allow color output", None, 'store_true', True),
-            'default-opt-level': ("Specify default optimisation level", 'choice', 'store', 'defaultopt',
+            'default-opt-level': ("Specify default optimisation level", 'choice', 'store', DEFAULT_OPT_LEVEL,
                                   Compiler.COMPILER_OPT_FLAGS),
             'deprecated': ("Run pretending to be (future) version, to test removal of deprecated code.",
                            None, 'store', None),

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -34,6 +34,8 @@ from easybuild.tools.config import build_option
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES
 from easybuild.tools.toolchain.toolchain import Toolchain
 
+# default optimization 'level' (see COMPILER_SHARED_OPTION_MAP/COMPILER_OPT_FLAGS)
+DEFAULT_OPT_LEVEL = 'defaultopt'
 
 # 'GENERIC' can  be used to enable generic compilation instead of optimized compilation (which is the default)
 # by doing eb --optarch=GENERIC
@@ -63,7 +65,7 @@ class Compiler(Toolchain):
         'pic': (False, "Use PIC"),  # also FFTW
         'noopt': (False, "Disable compiler optimizations"),
         'lowopt': (False, "Low compiler optimizations"),
-        'defaultopt': (False, "Default compiler optimizations"),  # not set, but default
+        DEFAULT_OPT_LEVEL: (False, "Default compiler optimizations"),  # not set, but default
         'opt': (False, "High compiler optimizations"),
         'optarch': (True, "Enable architecture optimizations"),
         'strict': (False, "Strict (highest) precision"),
@@ -94,7 +96,7 @@ class Compiler(Toolchain):
         'shared': 'shared',
         'noopt': 'O0',
         'lowopt': 'O1',
-        'defaultopt': 'O2',
+        DEFAULT_OPT_LEVEL: 'O2',
         'opt': 'O3',
         '32bit' : 'm32',
         'cstd': 'std=%(value)s',
@@ -104,7 +106,7 @@ class Compiler(Toolchain):
     COMPILER_GENERIC_OPTION = None
 
     COMPILER_FLAGS = ['debug', 'verbose', 'static', 'shared', 'openmp', 'pic', 'unroll']  # any compiler
-    COMPILER_OPT_FLAGS = ['noopt', 'lowopt', 'defaultopt', 'opt']  # optimisation args, ordered !
+    COMPILER_OPT_FLAGS = ['noopt', 'lowopt', DEFAULT_OPT_LEVEL, 'opt']  # optimisation args, ordered !
     COMPILER_PREC_FLAGS = ['strict', 'precise', 'defaultprec', 'loose', 'veryloose']  # precision flags, ordered !
 
     COMPILER_CC = None


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-framework/pull/1565

It sucks, but we need to specify the default value in two places something for "build options".

Importing `DEFAULT_OPT_LEVEL` into `config.py` would introduce a cyclic import...

It would be nice to clean that up somehow, but I'm not sure how we would do that.

Maybe by moving the logic that handes `build_option` to `options.py`...
