### PR TITLE
fix print_warning statement + use correct variable in log.info statement

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2901,10 +2901,10 @@ def build_and_install_one(ecdict, init_env):
             # move the reproducability files to the final log directory
             archive_reprod_dir = os.path.join(new_log_dir, os.path.basename(reprod_dir))
             if os.path.exists(archive_reprod_dir):
-                print_warning("Reproducability directory %s already exists, cannot overwrite", archive_reprod_dir)
+                print_warning("Reproducability directory %s already exists, cannot overwrite" % archive_reprod_dir)
             else:
                 copy_dir(reprod_dir, archive_reprod_dir)
-            _log.info("Wrote files for reproducability to %s", reprod_dir)
+            _log.info("Wrote files for reproducability to %s", archive_reprod_dir)
 
             try:
                 # upload easyconfig (and patch files) to central repository


### PR DESCRIPTION
Using `print_warning("...", foo)` never actually prints anything, because `print_warning` takes a named argument `silent`, see https://easybuild.readthedocs.io/en/latest/api/easybuild.tools.build_log.html#easybuild.tools.build_log.print_warning

So, `print_warning("...", foo)` is equivalent with `print_warning("...", silent=foo)`.

What you actually want is `print_warning("..." % foo)`

That's pretty nasty, I admit...
I'll look into making `print_warning` (and `print_msg`) a bit smarter to avoid this.